### PR TITLE
Add build_depend on rostest

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,7 @@
   <build_depend>opencv2</build_depend>
   <build_depend>openhrp3</build_depend>
   <build_depend>python-tk</build_depend>
+  <build_depend>rostest</build_depend>
   <build_depend>sdl</build_depend>
   <build_depend>subversion</build_depend>
 


### PR DESCRIPTION
While passes locally, `catkin_make` fails on [hydro pre-release test](http://jenkins.ros.org/job/prerelease-hydro-hrpsys/ARCH_PARAM=amd64,UBUNTU_PARAM=precise,label=prerelease/8/consoleFull):

```
sed -i s@/tmp/test_repositories/build_repository/devel/share@/tmp/test_repositories/src_repository/hrpsys/share@s /tmp/test_repositories/src_repository/hrpsys/share/hrpsys/samples/HRP4C//HRP4C.xml 
fix /tmp/test_repositories/build_repository/devel/lib/pkgconfig/hrpsys-base.pc
CMake Error at hrpsys/catkin.cmake:185 (add_rostest):
  Unknown CMake command "add_rostest".
Call Stack (most recent call first):
  hrpsys/CMakeLists.txt:2 (include)
```

Adding `rostest` following [this qa thread](http://answers.ros.org/question/65423/the-add_rostest-macro-is-not-being-recognized/).
