### PR TITLE
Parallel compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ clean: Makefile.hrpsys-base
 	-rm -fr installed include bin lib idl idl_gen msg msg_gen srv srv_gen src_gen
 
 download:
-	make -f Makefile.hrpsys-base download -j${PARALLEL_JOB}
+	make -f Makefile.hrpsys-base download -j${PARALLEL_JOB} -l${PARALLEL_JOB}


### PR DESCRIPTION
- compile hrpsys in parallel
- decide parallel jobs num according to /proc/cpuinfo
- up to 12 parallel jobs (too many parallel jobs may exhaust memory)
