### PR TITLE
start using 315.1.9, do not release until 315.1.9 is finally fixed

### DIFF
--- a/Makefile.hrpsys-base
+++ b/Makefile.hrpsys-base
@@ -3,7 +3,7 @@ all: installed
 INSTALL_DIR ?= ${CURDIR}
 SVN_DIR = build/hrpsys-base-source
 #SVN_URL = https://hrpsys-base.googlecode.com/svn/trunk
-SVN_URL = http://hrpsys-base.googlecode.com/svn/tags/315.1.8
+SVN_URL = http://hrpsys-base.googlecode.com/svn/tags/315.1.9
 #SVN_REVISION=-r@REVISION@
 
 OPENRTM_DIR ?= $(shell rospack find openrtm_aist)


### PR DESCRIPTION
see https://code.google.com/p/hrpsys-base/issues/detail?id=191, for 315.1.9, 
this will solve problem of test failure of rtmros_common, 

https://github.com/start-jsk/rtmros_common/pull/362, 
https://github.com/start-jsk/rtmros_common/pull/354 and so on
