### PR TITLE
add test for 315.1.9

### DIFF
--- a/test/test-colcheck.test
+++ b/test/test-colcheck.test
@@ -8,5 +8,5 @@
 
   <node name="colcheck" pkg="hrpsys" type="CollisionDetectorComp" output="screen"  cwd="node" />
 
-  <test test-name="testcolcheck" pkg="hrpsys" type="test-colcheck.py" />
+  <test test-name="colcheck" pkg="hrpsys" type="test-colcheck.py" />
 </launch>

--- a/test/test-hrpsys.test
+++ b/test/test-hrpsys.test
@@ -17,7 +17,7 @@
         args="$(find hrpsys)/share/hrpsys/samples/PA10/PA10monitor.xml" / -->
 
 
-  <test test-name="config_hostname" pkg="hrpsys" type="test-hostname.py" />
-  <test test-name="pkgconfig" pkg="hrpsys" type="test-pkgconfig.py" />
-  <test test-name="hrpsys_config" pkg="hrpsys" type="test-hrpsysconf.py" />
+  <test test-name="hrpsys_hostname" pkg="hrpsys" type="test-hostname.py" />
+  <test test-name="hrpsys_pkgconfig" pkg="hrpsys" type="test-pkgconfig.py" />
+  <test test-name="hrpsys_hrpsysconfig" pkg="hrpsys" type="test-hrpsysconf.py" args="--host 127.0.0.1 --port 2809"/>
 </launch>

--- a/test/test-hrpsysconf.py
+++ b/test/test-hrpsysconf.py
@@ -1,20 +1,49 @@
 #!/usr/bin/env python
 
 PKG = 'hrpsys'
-NAME = 'test-waitinput'
+NAME = 'test-hrpsys-config'
 
 import roslib; roslib.load_manifest('hrpsys')
-from hrpsys import hrpsys_config
+
+from hrpsys.hrpsys_config import *
+from hrpsys import rtm
+import OpenHRP
+
+import argparse,unittest,rostest
 
 import unittest, sys
 
+class SampleHrpsysConfigurator(HrpsysConfigurator):
+    def init(self, robotname="SampleRobot(Robot)0", url=""):
+         HrpsysConfigurator.init(self, robotname=robotname, url=url)
+
 class TestHrpsysConfig(unittest.TestCase):
+    global h
 
     def test_import_waitinput(self):
         # https://github.com/start-jsk/rtmros_hironx/blob/groovy-devel/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
         from waitInput import waitInputConfirm, waitInputSelect
         self.assertTrue(True)
 
+    def test_findcomp(self):
+        global h
+        h.findComps()
+
+    def setUp(self):
+        global h
+        parser = argparse.ArgumentParser(description='hrpsys command line interpreters')
+        parser.add_argument('--host', help='corba name server hostname')
+        parser.add_argument('--port', help='corba name server port number')
+        args, unknown = parser.parse_known_args()
+
+        if args.host:
+            rtm.nshost = args.host
+        if args.port:
+            rtm.nsport = args.port
+        h = SampleHrpsysConfigurator()
+
+
+#unittest.main()
 if __name__ == '__main__':
     import rostest
     rostest.run(PKG, NAME, TestHrpsysConfig, sys.argv)

--- a/test/test-jointangle.py
+++ b/test/test-jointangle.py
@@ -22,6 +22,7 @@ class PA10(HrpsysConfigurator):
             ['seq', "SequencePlayer"],
             ['sh', "StateHolder"],
             ['fk', "ForwardKinematics"],
+            ['log', "DataLogger"],
             ]
 
 
@@ -32,6 +33,13 @@ class TestJointAngle(unittest.TestCase):
     def setUpClass(self):
         h = PA10()
         h.init(robotname="PA10Controller(Robot)0")
+
+    def test_set_if_find_log(self):
+        h = PA10()
+        h.findComps()
+        print >>sys.stderr, "log=",h.log, "log_svc=",h.log_svc
+        self.assertTrue(h.log)
+        self.assertTrue(h.log_svc)
 
     def test_get_joint_angles(self):
         h = PA10()

--- a/test/test-pa10.test
+++ b/test/test-pa10.test
@@ -11,5 +11,6 @@
         args='-o "manager.modules.preload:hrpEC.so,RobotHardware.so,SequencePlayer.so,StateHolder.so,ForwardKinematics.so" -o "manager.components.precreate:RobotHardware" -f $(find hrpsys)/share/hrpsys/samples/PA10/rtc.conf -o "example.RobotHardware.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/RobotHardware.conf" -o "example.SequencePlayer.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "example.StateHolder.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "example.ForwardKinematics.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "corba.nameservers:localhost:2809" '
         output="screen"  cwd="node" />
 
-  <test test-name="test_jointangle" pkg="hrpsys" type="test-jointangle.py" />
+  <test test-name="pa10_jointangle" pkg="hrpsys" type="test-jointangle.py" />
+  <test test-name="pa10_hrpsysconf" pkg="hrpsys" type="test-hrpsysconf.py" args="--host 127.0.0.1 --port 2809"/>
 </launch>

--- a/test/test-simulator.test
+++ b/test/test-simulator.test
@@ -9,6 +9,6 @@
         args='$(find hrpsys)/share/hrpsys/samples/PA10/PA10simulation.xml -o manager.is_master:YES -o naming.formats:%n.rtc -o exec_cxt.periodic.rate:1000000 -o manager.shutdown_onrtcs:NO -o manager.modules.load_path:$(find hrpsys)/lib -o manager.modules.preload:HGcontroller.so -o manager.components.precreate:HGcontroller -o exec_cxt.periodic.type:SynchExtTriggerEC -f $(find hrpsys)/share/hrpsys/samples/PA10/rtc.conf -o "example.RobotHardware.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/RobotHardware.conf" -o "example.SequencePlayer.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "example.StateHolder.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "example.ForwardKinematics.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "corba.nameservers:localhost:2809" -nodisplay -endless'
         output="screen"  cwd="node" />
 
-  <test test-name="test_jointangle" pkg="hrpsys" type="test-jointangle.py"
-        retry="3" />
+  <test test-name="simulator_jointangle" pkg="hrpsys" type="test-jointangle.py" />
+  <test test-name="simulator_hrpsysconf" pkg="hrpsys" type="test-hrpsysconf.py" args="--port 2809"/>
 </launch>


### PR DESCRIPTION
hrpsys 315.1.9[1] solves significant improvement on failure if the test code
- update  findComps() wait for at least ten times ( 10 sec ) before finding RTC
- if findComps() could not find RTC successor findComp() did not wait for 10 sec
- test code[2] calls findComps() before calling other RTC methods

[1] https://code.google.com/p/hrpsys-base/source/diff?spec=svn1018&old=1016&r=1018&format=unidiff&path=%2Ftags%2F315.1.9%2Fpython%2Fhrpsys_config.py
[2] https://github.com/start-jsk/hrpsys/blob/master/test/test-jointangle.py#L38
