### PR TITLE
Add config test

### DIFF
--- a/test/test-jointangle.py
+++ b/test/test-jointangle.py
@@ -60,6 +60,15 @@ class TestJointAngle(unittest.TestCase):
         self.assertTrue(h.setJointAngles(h.getJointAngles(),1))
         self.assertEqual(h.waitInterpolation(), None)
 
+        import random
+        a = [(360*random.random()-180) for i in xrange(len(h.getJointAngles()))]
+        self.assertTrue(h.setJointAngles(a,2))
+        self.assertEqual(h.waitInterpolation(), None)
+
+        a = [0 for i in xrange(len(h.getJointAngles()))]
+        self.assertTrue(h.setJointAngles(a,2))
+        self.assertEqual(h.waitInterpolation(), None)
+
 #unittest.main()
 if __name__ == '__main__':
     rostest.run(PKG, NAME, TestJointAngle, sys.argv)

--- a/test/test-pkgconfig.py
+++ b/test/test-pkgconfig.py
@@ -26,6 +26,34 @@ class TestHrpsysPkgconfig(unittest.TestCase):
         if os.path.exists(os.path.join(hrpsys_path, "bin")) :
             self.PKG_CONFIG_PATH='PKG_CONFIG_PATH=%s/lib/pkgconfig:%s/lib/pkgconfig:$PKG_CONFIG_PATH'%(hrpsys_path, openhrp3_path)
 
+    def pkg_config_variable(self, var):
+        return check_output("%s pkg-config hrpsys-base --variable=%s"%(self.PKG_CONFIG_PATH, var), shell=True).rstrip()
+
+    def check_if_file_exists(self, var, fname):
+        pkg_var = var
+        pkg_dname = self.pkg_config_variable(pkg_var)
+        pkg_path = os.path.join(pkg_dname, fname)
+        pkg_ret = os.path.exists(pkg_path)
+        self.assertTrue(pkg_ret, "pkg-config hrpsys --variable=%s`/%s (%s) returns %r"%(pkg_var, fname, pkg_path, pkg_ret))
+
+
+    def check_if_file_exists_from_rospack(self, fname):
+        pkg_dname = check_output(['rospack','find','hrpsys']).rstrip()
+        pkg_path = os.path.join(pkg_dname, fname)
+        pkg_ret = os.path.exists(pkg_path)
+        self.assertTrue(pkg_ret, "`rospack find hrpsys`(%s) returns %r"%(pkg_path, pkg_ret))
+
+    def test_files_for_hrpsys(self):
+        # https://github.com/start-jsk/hrpsys/blob/master/test/test-pa10.test#L13
+        self.check_if_file_exists_from_rospack("share/hrpsys/samples/PA10/")
+        self.check_if_file_exists_from_rospack("share/hrpsys/samples/PA10/rtc.conf")
+        self.check_if_file_exists_from_rospack("share/hrpsys/samples/PA10/RobotHardware.conf")
+        self.check_if_file_exists_from_rospack("share/hrpsys/samples/PA10/PA10.conf")
+
+    def test_files_for_hrpsys_ros_bridge(self):
+        # https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/catkin.cmake#L50
+        self.check_if_file_exists("idldir", "HRPDataTypes.idl")
+
     def test_compile_iob(self):
         global PID
         cmd = "%s pkg-config hrpsys-base --cflags --libs"%(self.PKG_CONFIG_PATH)


### PR DESCRIPTION
similar to issue discussed in start-jsk/openrtm_aist_core#1
currently hrpsys-base provides following information

```
prefix=/home/k-okada/catkin_ws/ws_openrtm_common/devel
exec_prefix=${prefix}/bin
libdir=${prefix}/lib
idldir=/home/k-okada/catkin_ws/ws_openrtm_common/src/rtm-ros-robotics/openrtm_common/hrpsys/share/hrpsys/idl
includedir=-I${prefix}/include/hrpsys -I${prefix}/include/hrpsys/idl
link_shared_files=
link_static_files=
link_depend_dirs=
link_depend_files=
link_depend_options=
cflag_defs=
cflag_options=
```
