### PR TITLE
remove installed file if openhrp3_FOUND is not found

### DIFF
--- a/catkin.cmake
+++ b/catkin.cmake
@@ -12,6 +12,9 @@ find_package(catkin REQUIRED COMPONENTS rostest mk openrtm_aist openhrp3)
 # <install>/lib/<package>/RobotHardware # rosrun hrpsys RobtoHardware works
 # <install>/lib/RobotHardware.so # so that `rospack find hrspsys`/lib can find .so
 # <install>/<package>/share
+if(NOT hrpsys_FOUND)
+  file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/installed)
+endif()
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/installed)
   set(ENV{PATH} ${openrtm_aist_PREFIX}/lib/openrtm_aist/bin/:$ENV{PATH}) #update PATH for rtm-config
   execute_process(


### PR DESCRIPTION
this is similar patch to https://github.com/start-jsk/openrtm_aist_core/pull/50 and https://github.com/start-jsk/openhrp3/issues/44,

this allow users to 

```
catkin_make
rm build/CMakeCache.txt
catkin_make
```
