### PR TITLE
rm hrpsys-base/CMakeCache.txt when compile

### DIFF
--- a/Makefile.hrpsys-base
+++ b/Makefile.hrpsys-base
@@ -33,6 +33,7 @@ ifneq ($(strip $(GIT_PATCH)),)
 	touch rospack_nosubdirs
 	touch patched
 endif
+	rm -f build/hrpsys-base/CMakeCache.txt
 	@echo "compile hrpsys-base ... "
 	@echo "                 PATH=$(PATH)"
 	@echo "                 INSTALL_DIR=$(INSTALL_DIR)"


### PR DESCRIPTION
this is workaround for following situation:

```
make[2]: *** [rtc/OccupancyGridMap3D/CMakeFiles/OccupancyGridMap3D.dir/all] エ\\
ラー 2
make[2]: *** 未完了のジョブを待っています....
[ 65%] Building CXX object rtc/OccupancyGridMap3D/CMakeFiles/OccupancyGridMap3D\
Comp.dir/OGMap3DService_impl.o
Linking CXX executable ../../bin/OccupancyGridMap3DComp
/usr/bin/ld: cannot find -loctomap
/usr/bin/ld: cannot find -loctomath
collect2: ld はステータス 1 で終了しました
```
