### PR TITLE
Add samplerobot-sequence-player and samplerobot-collision-detector

### DIFF
--- a/samples/samplerobot-collision-detector.py
+++ b/samples/samplerobot-collision-detector.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+"""
+ this is example file for SampleRobot robot
+
+ $ roslaunch hrpsys samplerobot.launch
+ $ rosrun    hrpsys samplerobot-collision-detector.py
+
+"""
+import imp, sys, os
+
+# set path to hrpsys to use HrpsysConfigurator
+try:
+    imp.find_module('hrpsys') # catkin installed
+    sys.path.append(imp.find_module('hrpsys')[1])
+except: # rosbuild installed
+    import roslib
+    roslib.load_manifest('hrpsys')
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__))+'/../share/hrpsys/samples/SampleRobot/') # set path to SampleRobot
+
+import samplerobot_collision_detector
+
+if __name__ == '__main__':
+    samplerobot_collision_detector.demo()
+
+## IGNORE ME: this code used for rostest
+if [s for s in sys.argv if "--gtest_output=xml:" in s] :
+    import unittest, rostest
+    rostest.run('hrpsys', 'samplerobot_collision_detector', unittest.TestCase, sys.argv)

--- a/samples/samplerobot-sequence-player.py
+++ b/samples/samplerobot-sequence-player.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+"""
+ this is example file for SampleRobot robot
+
+ $ roslaunch hrpsys samplerobot.launch
+ $ rosrun    hrpsys samplerobot-sequence-player.py
+
+"""
+import imp, sys, os
+
+# set path to hrpsys to use HrpsysConfigurator
+try:
+    imp.find_module('hrpsys') # catkin installed
+    sys.path.append(imp.find_module('hrpsys')[1])
+except: # rosbuild installed
+    import roslib
+    roslib.load_manifest('hrpsys')
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__))+'/../share/hrpsys/samples/SampleRobot/') # set path to SampleRobot
+
+import samplerobot_sequence_player
+
+if __name__ == '__main__':
+    samplerobot_sequence_player.demo()
+
+## IGNORE ME: this code used for rostest
+if [s for s in sys.argv if "--gtest_output=xml:" in s] :
+    import unittest, rostest
+    rostest.run('hrpsys', 'samplerobot_sequence_player', unittest.TestCase, sys.argv)


### PR DESCRIPTION
Add samplerobot-sequence-player and samplerobot-collision-detector which are ROS-user wrapper of hrpsys-base samples.

In the near future, hrpsys will merged to hrpsys-base and these samples can be moved to hrpsys-base[1].
But currently I added these examples here.
[1] https://github.com/start-jsk/rtmros_common/issues/579
