### PR TITLE
Add sample wrapper for samplerobot kalman filter

### DIFF
--- a/samples/samplerobot-kalman-filter.py
+++ b/samples/samplerobot-kalman-filter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+"""
+ this is example file for SampleRobot robot
+
+ $ roslaunch hrpsys samplerobot.launch
+ $ rosrun    hrpsys samplerobot-kalman-filter.py
+
+"""
+import imp, sys, os
+
+# set path to hrpsys to use HrpsysConfigurator
+try:
+    imp.find_module('hrpsys') # catkin installed
+    sys.path.append(imp.find_module('hrpsys')[1])
+except: # rosbuild installed
+    import roslib
+    roslib.load_manifest('hrpsys')
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__))+'/../share/hrpsys/samples/SampleRobot/') # set path to SampleRobot
+
+import samplerobot_kalman_filter
+
+if __name__ == '__main__':
+    samplerobot_kalman_filter.demo()
+
+## IGNORE ME: this code used for rostest
+if [s for s in sys.argv if "--gtest_output=xml:" in s] :
+    import unittest, rostest
+    rostest.run('hrpsys', 'samplerobot_kalman_filter', unittest.TestCase, sys.argv)
+
+
+
+
+
+


### PR DESCRIPTION
Add samplerobot-kalman-filter which are ROS-user wrapper of hrpsys-base samples.

In the near future, hrpsys will merged to hrpsys-base and these samples can be moved to hrpsys-base[1].
But currently I added these examples here.
[1] start-jsk/rtmros_common#579
